### PR TITLE
Update Readme to include the version of Select2 used by the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,37 +3,39 @@
 [Select2](https://github.com/ivaynberg/select2) is a jQuery based replacement for select boxes. It supports searching, remote data sets, and infinite scrolling of results.
 
 
-The `select2-rails` gem integrates the `Select2` with the Rails asset pipeline.
+The `select2-rails` gem integrates the `Select2` jQuery plugin with the Rails asset pipeline.
 
 ## Usage
 
 ### Install select2-rails gem
 
-Add `select2-rails` in Gemfile and run `bundle install`.
+Add `select2-rails` to your Gemfile and run `bundle install`:
 
 	gem "select2-rails"
 
 ### Include select2-rails javascript assets
 
-Add to your `app/assets/javascripts/application.js`.
+Add the following to your `app/assets/javascripts/application.js`:
 
 	//= require select2
 
 ### Include select2-rails stylesheet assets
 
-Add to your `app/assets/stylesheets/application.css`.
+Add to your `app/assets/stylesheets/application.css`:
 
 	*= require select2
-	
+
 ## Version
-The most current release of `select2-rails` uses `Select2 v2.1`.
+From `v2.1.0` on, `select2-rails`'s version will match the version of `Select2` it uses. Currently, `select2-rails` uses `Select2 v2.1`.
+
+The last number of the version is the patch version specific to the gem. For example, for a version of the form `2.x.y`, `2.x` is the release of `Select2` we should be compatible with, and y is the patch version specific to the gem (ie. to resolve any gem-specific issues that crop up).
 
 ## Contributions
 
 If you wont to contribute, please:
 
 	* Fork the project.
-	* Make your feature addition or bug fix.	
+	* Make your feature addition or bug fix.
 	* Send me a pull request on Github.
 
 ## Copyright

--- a/lib/select2-rails/version.rb
+++ b/lib/select2-rails/version.rb
@@ -1,5 +1,5 @@
 module Select2
   module Rails
-    VERSION = "0.0.9"
+    VERSION = "2.1.0"
   end
 end


### PR DESCRIPTION
The Readme should be updated to always show the latest version of Select2 the gem uses - otherwise, it's not altogether clear how current the gem is with the plugin. I modified the Readme to include a Version section, to highlight the version of Select2 used by the latest release.
