### PR TITLE
Fix tagging input style.

### DIFF
--- a/vendor/assets/stylesheets/select2.css.sass
+++ b/vendor/assets/stylesheets/select2.css.sass
@@ -167,7 +167,7 @@
     -o-box-shadow: 0 -4px 5px rgba(0, 0, 0, 0.15)
     box-shadow: 0 -4px 5px rgba(0, 0, 0, 0.15)
 
-.select2-container div
+.select2-container .select2-choice div
   -webkit-border-radius: 0 4px 4px 0
   -moz-border-radius: 0 4px 4px 0
   border-radius: 0 4px 4px 0


### PR DESCRIPTION
Hey,

I'm not sure why you're converting Select2's stylesheet to .sass, but it seems something went wrong with the styles for the 'tagging' feature.

The fix is very simple, but I strongly suggest to just import the plugin's original CSS files, to avoid these things in the future.
