### PR TITLE
FIxed gem version number

### DIFF
--- a/lib/select2-rails/version.rb
+++ b/lib/select2-rails/version.rb
@@ -1,5 +1,5 @@
 module Select2
   module Rails
-    VERSION = "3.2.2"
+    VERSION = "3.3.0"
   end
 end


### PR DESCRIPTION
We were already using select2 3.3.0 but the gem version wasn't updated.
