### PR TITLE
Alter instruction for including bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add to your `app/assets/stylesheets/application.css`:
 
 	*= require select2
 
-If you are using Twitter Boostrap you can require the bootstrap theme CSS
+If you are using Twitter Boostrap you need to also require the bootstrap theme CSS in addition to the above require.
 
 	*= require select2-bootstrap
 


### PR DESCRIPTION
The current instruction isn't clear on whether the require select2-boostrap is needed in place of or in addition to the regular select2 require.  Hopefully, this should save first time users some time figuring that out.
