### PR TITLE
Fix rake task for update select2 files

### DIFF
--- a/lib/select2-rails/source_file.rb
+++ b/lib/select2-rails/source_file.rb
@@ -41,7 +41,7 @@ class SourceFile < Thor
   private
 
   def fetch_tags
-    http = HTTPClient.new(agent_name: 'chilian/select2-rails')
+    http = HTTPClient.new(agent_name: 'select2-rails')
     response = JSON.parse(http.get("https://api.github.com/repos/ivaynberg/select2/tags").body)
     response.map{|tag| tag["name"]}.sort
   end


### PR DESCRIPTION
I added a fake user_agent - otherwise you will get the following error if u run the rake task `update-select2`:

```
JSON::ParserError: 757: unexpected token at 'Request forbidden by administrative rules. Please make sure your request has a User-Agent header (http://developer.github.com/v3/#user-agent-required). Check https://developer.github.com for other possible causes.
```
