### PR TITLE
Correct extension for application.css.scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the following to your `app/assets/javascripts/application.js`:
 
 ### Include select2-rails stylesheet assets
 
-Add to your `app/assets/stylesheets/application.css`:
+Add to your `app/assets/stylesheets/application.css.scss`:
 
 	*= require select2
 


### PR DESCRIPTION
SCSS is enabled by default so most Rails projects will have an application.css.scss rather than application.css.
