### PR TITLE
Add sass-rails as development dependencies

### DIFF
--- a/select2-rails.gemspec
+++ b/select2-rails.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", "~> 1.0"
   s.add_development_dependency "rails", ">= 3.0"
   s.add_development_dependency "httpclient", "~> 2.2"
+  s.add_development_dependency "sass-rails", ">= 5.0"
 end


### PR DESCRIPTION
Add sass-rails as development dependencies.
Because there is a *.scss file but sass-rails was not in dependencies.
