### PR TITLE
Fixed missing 'depend_on_asset' directives in select2.scss

### DIFF
--- a/lib/select2-rails/version.rb
+++ b/lib/select2-rails/version.rb
@@ -1,5 +1,5 @@
 module Select2
   module Rails
-    VERSION = "3.5.9.3"
+    VERSION = "3.5.9.4"
   end
 end

--- a/vendor/assets/stylesheets/select2.scss
+++ b/vendor/assets/stylesheets/select2.scss
@@ -1,3 +1,7 @@
+//= depend_on_asset "select2.png"
+//= depend_on_asset "select2-spinner.gif"
+//= depend_on_asset "select2x2.png"
+
 /*
 Version: 3.5.2 Timestamp: Sat Nov  1 14:43:36 EDT 2014
 */


### PR DESCRIPTION
Related to issues #126 and #70 
I just added the missing directives and incremented the version number
