### PR TITLE
Thor should be a development dependency only

### DIFF
--- a/select2-rails.gemspec
+++ b/select2-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "thor", "~> 0.14"
+  s.add_development_dependency "thor", "~> 0.14"
   s.add_development_dependency "bundler", "~> 1.0"
   s.add_development_dependency "rails", ">= 3.0"
   s.add_development_dependency "httpclient", "~> 2.2"


### PR DESCRIPTION
Thor is being used to download and update the gem itself (as far as I understand), this just change the dependency type, to prevent issues with dependencies.