### PR TITLE
upgrade thor

### DIFF
--- a/select2-rails.gemspec
+++ b/select2-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "thor", "~> 0.14"
+  s.add_development_dependency "thor", "~> 1"
   s.add_development_dependency "bundler", "~> 1.0"
   s.add_development_dependency "rails", ">= 3.0"
   s.add_development_dependency "httpclient", "~> 2.2"


### PR DESCRIPTION
This solves `Bundler could not find compatible versions for gem "thor":` with other gems like solargraph