### PR TITLE
Make thor a development dependency in 3.5

### DIFF
--- a/lib/select2-rails/version.rb
+++ b/lib/select2-rails/version.rb
@@ -1,5 +1,5 @@
 module Select2
   module Rails
-    VERSION = "3.5.10"
+    VERSION = "3.5.11"
   end
 end

--- a/select2-rails.gemspec
+++ b/select2-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "thor", "~> 0.14"
+  s.add_development_dependency "thor", "~> 0.14"
   s.add_development_dependency "bundler", "~> 1.0"
   s.add_development_dependency "rails", ">= 3.0"
   s.add_development_dependency "httpclient", "~> 2.2"

--- a/select2-rails.gemspec
+++ b/select2-rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "thor", "~> 0.14"
-  s.add_development_dependency "bundler", "~> 1.0"
+  s.add_development_dependency "bundler", "~> 2.0"
   s.add_development_dependency "rails", ">= 3.0"
   s.add_development_dependency "httpclient", "~> 2.2"
 end


### PR DESCRIPTION
This might break new usage of the gem, but this allows users on 3.5.x to use Rails 6.1.