### PR TITLE
Bump thor from ~> 0.14 to 1

### DIFF
--- a/select2-rails.gemspec
+++ b/select2-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "thor", "~> 0.14"
+  s.add_development_dependency "thor", "~> 1"
   s.add_development_dependency "bundler", "~> 2.0"
   s.add_development_dependency "rails", ">= 3.0"
   s.add_development_dependency "httpclient", "~> 2.2"


### PR DESCRIPTION
[WIP]

`select2-rails`'s usage of `thor` is not broken by the more recent versions of it so this loosens up the restriction. Specifically helps utilize `select2-rails` with Ruby 3.